### PR TITLE
Add team captains functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-game.json
+games.json
 config.json
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+game.json
 config.json
 node_modules

--- a/commands/captains/team_captains.js
+++ b/commands/captains/team_captains.js
@@ -1,0 +1,58 @@
+const {SlashCommandBuilder, ChannelType } = require('discord.js');
+const crypto = require('crypto');
+const Game = require('./../../models/game');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('team_captains')
+        .setDescription('Start a team captain style draft for team selection'),
+    async execute(interaction) {
+        const vc = (interaction.member.voice.channel ?? false)
+        if(!interaction.member.voice.channel) {
+            await interaction.reply({content:`Must be in a voice channel to start team captains draft`,ephemeral:true})
+            return
+        }
+
+        const members = vc.members
+        // if(members.size < 2){
+        //     await interaction.reply(`Insufficient number of players to create teams`)
+        //     return
+        // }
+
+        await interaction.deferReply();
+
+        let guild = interaction.guild;
+        const captain1 = pickRandomCaptains(members)
+        // const [captain1, captain2] = pickRandomCaptains(members)
+        let gameId = generateUniqueGameId(guild.id, interaction.member.id)
+        let game = new Game(gameId)
+        game.setCaptains(captain1)
+        // game.setCaptains(captain1, captain2);
+        game.save();
+
+        await interaction.followUp(`Your team captains are ${captain1.displayName} and ...`);
+        return
+    }
+};
+
+function pickRandomCaptains(members){
+    let players = Array.from(members.values())
+    console.log(`potential captains - ${JSON.stringify(players)}`)
+    let captain1Index = Math.floor(Math.random() * players.length)
+    let captain1 = players[captain1Index]
+    players.splice(captain1Index, 1)
+    return captain1
+    // let captain2Index = Math.floor(Math.random() * players.length)
+    // let captain2 = players[captain2Index]
+    // return [captain1, captain2]
+}
+
+function generateUniqueGameId(guildId, creatorId){
+  const data = `${guildId}-${creatorId}`;
+
+  // Create a hash using SHA256
+  const hash = crypto.createHash('sha256').update(data).digest('hex');
+  const identifier = hash.substring(0, 16);
+
+  return identifier;
+}

--- a/commands/captains/team_captains.js
+++ b/commands/captains/team_captains.js
@@ -26,7 +26,9 @@ module.exports = {
         game.setCaptains(captain1, captain2);
         game.saveNewGame();
 
-        await interaction.followUp(`Your team captains are ${captain1.displayName} and ${captain2.displayName}`);
+        await interaction.followUp(`Your team captains are ${captain1.displayName} and ${captain2.displayName}
+                                    \n${captain1.displayName} gets first pick
+                                    \`\`\`Use /draft to draft a player\`\`\``);
         return
     }
 };

--- a/commands/captains/team_captains.js
+++ b/commands/captains/team_captains.js
@@ -13,7 +13,7 @@ module.exports = {
         }
 
         const members = vc.members
-        // if(members.size < 2){
+        // if(members.size < 3){
         //     await interaction.reply(`Insufficient number of players to create teams`)
         //     return
         // }
@@ -27,12 +27,12 @@ module.exports = {
 
         const [captain1, captain2] = pickRandomCaptains(members)
         let game = new Game(interaction.guild.id, interaction.member.id)
-        game.availablePlayers = Array.from(members.values())
+        game.availablePlayers = [...members.values()]
         game.setCaptains(captain1, captain2);
         game.saveNewGame();
 
         await interaction.followUp(`Your captains are ${captain1.toString()} and ${captain2.toString()}
-                                    \n${captain1.displayName} gets first pick
+                                    \n${captain1.toString()} gets first pick
                                     \`\`\`Use /draft to begin the player draft\`\`\``);
         return
     }
@@ -40,11 +40,10 @@ module.exports = {
 
 function pickRandomCaptains(members){
     let players = Array.from(members.values())
-    console.log(`potential captains - ${JSON.stringify(players)}`)
     let captain1Index = Math.floor(Math.random() * players.length)
     let captain1 = players[captain1Index]
-    // players.splice(captain1Index, 1)
-    // let captain2Index = Math.floor(Math.random() * players.length)
-    // let captain2 = players[captain2Index]
-    return [captain1, captain1]
+    players.splice(captain1Index, 1)
+    let captain2Index = Math.floor(Math.random() * players.length)
+    let captain2 = players[captain2Index]
+    return [captain1, captain2]
 }

--- a/commands/captains/team_captains.js
+++ b/commands/captains/team_captains.js
@@ -26,9 +26,9 @@ module.exports = {
         game.setCaptains(captain1, captain2);
         game.saveNewGame();
 
-        await interaction.followUp(`Your team captains are ${captain1.displayName} and ${captain2.displayName}
+        await interaction.followUp(`Your captains are ${captain1.toString()} and ${captain2.toString()}
                                     \n${captain1.displayName} gets first pick
-                                    \`\`\`Use /draft to draft a player\`\`\``);
+                                    \`\`\`Use /draft to begin the player draft\`\`\``);
         return
     }
 };

--- a/commands/captains/team_captains.js
+++ b/commands/captains/team_captains.js
@@ -4,7 +4,7 @@ const Game = require('./../../models/game');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('team_captains')
-        .setDescription('Start a team captain style draft for team selection'),
+        .setDescription('Randomly picks team captains for team selection'),
     async execute(interaction) {
         const vc = (interaction.member.voice.channel ?? false)
         if(!interaction.member.voice.channel) {
@@ -17,6 +17,11 @@ module.exports = {
         //     await interaction.reply(`Insufficient number of players to create teams`)
         //     return
         // }
+
+        if(members.size > 10) {
+            await interaction.reply(`Cannot begin a team captains draft with more than 10 total players`)
+            return
+        }
 
         await interaction.deferReply();
 

--- a/commands/captains/team_captains.js
+++ b/commands/captains/team_captains.js
@@ -1,5 +1,4 @@
-const {SlashCommandBuilder, ChannelType } = require('discord.js');
-const crypto = require('crypto');
+const { SlashCommandBuilder } = require('discord.js');
 const Game = require('./../../models/game');
 
 module.exports = {
@@ -21,16 +20,13 @@ module.exports = {
 
         await interaction.deferReply();
 
-        let guild = interaction.guild;
-        const captain1 = pickRandomCaptains(members)
-        // const [captain1, captain2] = pickRandomCaptains(members)
-        let gameId = generateUniqueGameId(guild.id, interaction.member.id)
-        let game = new Game(gameId)
-        game.setCaptains(captain1)
-        // game.setCaptains(captain1, captain2);
-        game.save();
+        const [captain1, captain2] = pickRandomCaptains(members)
+        let game = new Game(interaction.guild.id, interaction.member.id)
+        game.availablePlayers = Array.from(members.values())
+        game.setCaptains(captain1, captain2);
+        game.saveNewGame();
 
-        await interaction.followUp(`Your team captains are ${captain1.displayName} and ...`);
+        await interaction.followUp(`Your team captains are ${captain1.displayName} and ${captain2.displayName}`);
         return
     }
 };
@@ -40,19 +36,8 @@ function pickRandomCaptains(members){
     console.log(`potential captains - ${JSON.stringify(players)}`)
     let captain1Index = Math.floor(Math.random() * players.length)
     let captain1 = players[captain1Index]
-    players.splice(captain1Index, 1)
-    return captain1
+    // players.splice(captain1Index, 1)
     // let captain2Index = Math.floor(Math.random() * players.length)
     // let captain2 = players[captain2Index]
-    // return [captain1, captain2]
-}
-
-function generateUniqueGameId(guildId, creatorId){
-  const data = `${guildId}-${creatorId}`;
-
-  // Create a hash using SHA256
-  const hash = crypto.createHash('sha256').update(data).digest('hex');
-  const identifier = hash.substring(0, 16);
-
-  return identifier;
+    return [captain1, captain1]
 }

--- a/commands/draft/draft.js
+++ b/commands/draft/draft.js
@@ -5,7 +5,7 @@ const GameRepo = require('./../../repos/gameRepo');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('draft')
-        .setDescription('Draft an available player to your team'),
+        .setDescription('Begin the player draft'),
     async execute(interaction) {
         const vc = (interaction.member.voice.channel ?? false)
         if(!interaction.member.voice.channel) {
@@ -21,12 +21,12 @@ module.exports = {
             return
         }
 
-        let userTurn = game.whoseTurnToPick()
-        if(interaction.member.id !== userTurn.userId){
-            await interaction.followUp(`It is not your turn to draft a player. Try again after the other captain has drafted`);
+        if(interaction.member.id !== game.captain1.userId && interaction.member.id !== game.captain2.userId) {
+            await interaction.followUp({content:`Only team captains can start the draft`, ephemeral: true})
             return
         }
 
+        let userTurn = game.whoseTurnToPick()
         const userSelect = new StringSelectMenuBuilder().setCustomId(game.id);
         for (const player of game.availablePlayers) {
             userSelect
@@ -38,6 +38,6 @@ module.exports = {
         }
         const row = new ActionRowBuilder().addComponents(userSelect);
 
-        return await interaction.followUp({content: `Draft Pick for ${userTurn.displayName}`, components: [row]})
+        return await interaction.followUp({content: `Next pick: ${userTurn.displayName}`, components: [row]})
     }
 }

--- a/commands/draft/draft.js
+++ b/commands/draft/draft.js
@@ -13,7 +13,7 @@ module.exports = {
             return
         }
 
-        let game = GameRepo.getGameByCaptainId(interaction.member.id)
+        let game = GameRepo.getGameByCaptainIdAndServerId(interaction.member.id, interaction.guild.id)
         if(!game){
             await interaction.reply(`You must be a captain of an ongoing game to use this command.`)
             return

--- a/commands/draft/draft.js
+++ b/commands/draft/draft.js
@@ -13,19 +13,21 @@ module.exports = {
             return
         }
 
+        await interaction.deferReply();
+
         let game = GameRepo.getGameByCaptainIdAndServerId(interaction.member.id, interaction.guild.id)
-        if(!game){
-            await interaction.reply(`You must be a captain of an ongoing game to use this command.`)
+        if(!(game instanceof Game)){
+            await interaction.followUp(`You must be a captain of an ongoing game to use this command.`)
             return
         }
 
         let userTurn = game.whoseTurnToPick()
-        if(interaction.member.id !== userTurn.id){
-            await interaction.reply(`It is not your turn to draft a player. Try again after the other captain has drafted`);
+        if(interaction.member.id !== userTurn.userId){
+            await interaction.followUp(`It is not your turn to draft a player. Try again after the other captain has drafted`);
             return
         }
 
 
-        console.log('you may draft a player')
+        interaction.followUp(`You may draft a player`)
     }
 }

--- a/commands/draft/draft.js
+++ b/commands/draft/draft.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, ActionRowBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder } = require('discord.js');
 const Game = require('./../../models/game');
 const GameRepo = require('./../../repos/gameRepo');
 
@@ -27,7 +27,17 @@ module.exports = {
             return
         }
 
+        const userSelect = new StringSelectMenuBuilder().setCustomId(game.id);
+        for (const player of game.availablePlayers) {
+            userSelect
+                .addOptions(
+                    new StringSelectMenuOptionBuilder()
+                        .setLabel(player.displayName)
+                        .setValue(player.userId)
+                )
+        }
+        const row = new ActionRowBuilder().addComponents(userSelect);
 
-        interaction.followUp(`You may draft a player`)
+        return await interaction.followUp({content: `Draft Pick for ${userTurn.displayName}`, components: [row]})
     }
 }

--- a/commands/draft/draft.js
+++ b/commands/draft/draft.js
@@ -1,0 +1,31 @@
+const { SlashCommandBuilder } = require('discord.js');
+const Game = require('./../../models/game');
+const GameRepo = require('./../../repos/gameRepo');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('draft')
+        .setDescription('Draft an available player to your team'),
+    async execute(interaction) {
+        const vc = (interaction.member.voice.channel ?? false)
+        if(!interaction.member.voice.channel) {
+            await interaction.reply({content:`Must be in a voice channel to start team captains draft`,ephemeral:true})
+            return
+        }
+
+        let game = GameRepo.getGameByCaptainId(interaction.member.id)
+        if(!game){
+            await interaction.reply(`You must be a captain of an ongoing game to use this command.`)
+            return
+        }
+
+        let userTurn = game.whoseTurnToPick()
+        if(interaction.member.id !== userTurn.id){
+            await interaction.reply(`It is not your turn to draft a player. Try again after the other captain has drafted`);
+            return
+        }
+
+
+        console.log('you may draft a player')
+    }
+}

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -1,22 +1,26 @@
 const { Events } = require('discord.js')
+const draftHandler = require('../handlers/draftHandler')
 
 module.exports = {
     name: Events.InteractionCreate,
     async execute(interaction) {
-        if(!interaction.isChatInputCommand()) return
+        if(interaction.isChatInputCommand()) {
+			const command = interaction.client.commands.get(interaction.commandName)
 
-        const command = interaction.client.commands.get(interaction.commandName)
+			if (!command) {
+				console.error(`Unrecognized command: ${interaction.commandName}`)
+				return
+			}
+	
+			try {
+				await command.execute(interaction)
+			} catch (error) {
+				console.error(`An error occurred`)
+				console.error(error)
+			}
 
-        if (!command) {
-			console.error(`Unrecognized command: ${interaction.commandName}`)
-			return
-		}
-
-		try {
-			await command.execute(interaction)
-		} catch (error) {
-			console.error(`An error occurred`)
-			console.error(error)
+		} else if (interaction.isStringSelectMenu()) {
+			draftHandler.execute(interaction)
 		}
     }
 }

--- a/handlers/draftHandler.js
+++ b/handlers/draftHandler.js
@@ -1,0 +1,45 @@
+const { StringSelectMenuBuilder, StringSelectMenuOptionBuilder, ActionRow, ActionRowBuilder } = require('discord.js');
+const Game = require('../models/game');
+const GameRepo = require('./../repos/gameRepo');
+
+module.exports = {
+    data: { name: 'Draft Handler'},
+    async execute(interaction){
+        await interaction.deferUpdate();
+        
+        console.log(interaction)
+        let game = GameRepo.getGameByGuildIdAndGameId(interaction.guildId, interaction.customId)
+        if(!(game instanceof Game)){
+            await interaction.followUp({content: 'Unable to find game', ephemeral: true})
+            return
+        }
+
+        if(interaction.user.id !== game.captain1.userId && interaction.user.id !== game.captain2.userId) {
+            await interaction.followUp({content: `Only team captains can draft players`, ephemeral: true})
+            return
+        }
+
+        let draftPickTurnUser = game.whoseTurnToPick()
+        if(interaction.user.id !== draftPickTurnUser.userId){
+            await interaction.followUp({content: `Current pick: ${draftPickTurnUser.user}\nPlease wait till they have made a pick`, ephemeral: true})
+            return
+        }
+
+        game.lastPick = draftPickTurnUser.userId
+        let nextPickUser = game.whoseTurnToPick()
+
+        const userSelect = new StringSelectMenuBuilder().setCustomId(interaction.customId);
+        for (const player of game.availablePlayers) {
+            userSelect
+                .addOptions(
+                    new StringSelectMenuOptionBuilder()
+                        .setLabel(player.displayName)
+                        .setValue(player.userId)
+                )
+        }
+        const row = new ActionRowBuilder().addComponents(userSelect);
+        await interaction.editReply({content: `Draft pick for ${nextPickUser.displayName}`, components: [row]})
+
+        // return interaction.followUp({content: `Eligible pick. Excecuting draft logic and updating game`})
+    }
+}

--- a/handlers/draftHandler.js
+++ b/handlers/draftHandler.js
@@ -1,6 +1,7 @@
-const { StringSelectMenuBuilder, StringSelectMenuOptionBuilder, ActionRow, ActionRowBuilder } = require('discord.js');
+const { StringSelectMenuBuilder, StringSelectMenuOptionBuilder, ActionRowBuilder, ChannelType, ButtonBuilder, ButtonStyle } = require('discord.js');
 const Game = require('../models/game');
 const GameRepo = require('./../repos/gameRepo');
+const { team1VCName, team2VCName, categoryChannelName } = require('./../config.json');
 
 module.exports = {
     data: { name: 'Draft Handler'},
@@ -18,6 +19,17 @@ module.exports = {
             return
         }
 
+        if(interaction.values[0] === 'start' && game.availablePlayers.length !== 0) {
+            await interaction.followUp({content: `The game is not ready to start. There are still undrafted players`})
+            return
+        }
+
+        if(interaction.values[0] === 'start' && game.availablePlayers.length === 0) {
+            await interaction.followUp({content: `Game is starting...`})
+            await startGame(interaction, game)
+            return
+        }
+
         let draftPickTurnUser = game.whoseTurnToPick()
         if(interaction.user.id !== draftPickTurnUser.userId){
             await interaction.followUp({content: `Current pick: ${draftPickTurnUser.user}\nPlease wait till they have made a pick`, ephemeral: true})
@@ -26,29 +38,72 @@ module.exports = {
         
         let chosenPlayerId = interaction.values[0]
         const [draftPick, team]  = game.draftPlayer(chosenPlayerId, draftPickTurnUser.userId)
+        game.appendToDraftLog(`${draftPick.displayName} has been drafted to ${team} by ${interaction.user.username}`);
         game.update()
 
-        await interaction.followUp({content: `${draftPick.displayName} has been drafted to ${team} by ${interaction.user.username}`})
+
+        // await interaction.followUp({content: `${game.draftLog}`})
         let nextPickUser = game.whoseTurnToPick()
 
-
-        // remove the select menu if there are no more available players to draft
-        if(game.availablePlayers.length === 0) {
-            await interaction.editReply({content: `All players have been drafted`, components: []})
-            return
-        }
-
         const userSelect = new StringSelectMenuBuilder().setCustomId(interaction.customId);
-        for (const player of game.availablePlayers) {
+        if(game.availablePlayers.length === 0) {
+            let msg = `\n\`\`\`All players have been drafted. Select 'Start Game' to start the game\`\`\``
+            game.appendToDraftLog(msg)
             userSelect
                 .addOptions(
                     new StringSelectMenuOptionBuilder()
-                        .setLabel(player.displayName)
-                        .setValue(player.userId)
+                        .setLabel('Start Game')
+                        .setValue('start')
                 )
+        } else {
+            let msg = `Next pick: ${nextPickUser.displayName}`
+            game.appendToDraftLog(msg)
+            for (const player of game.availablePlayers) {
+                userSelect
+                    .addOptions(
+                        new StringSelectMenuOptionBuilder()
+                            .setLabel(player.displayName)
+                            .setValue(player.userId)
+                    )
+            }
         }
 
         const row = new ActionRowBuilder().addComponents(userSelect);
-        await interaction.editReply({content: `Next pick: ${nextPickUser.displayName}`, components: [row]})
+        await interaction.editReply({content: game.draftLog, components: [row]})
     }
+}
+
+async function startGame(interaction, game){
+    // create channels
+    let categoryChannel = await interaction.member.guild.channels.create({name: categoryChannelName, type: ChannelType.GuildCategory})
+
+    let vc1Options = {
+        name: team1VCName,
+        type: ChannelType.GuildVoice,
+        userLimit: game.team1.length + 1,
+        reason: "VC1 for Valorant custom match"
+    }
+
+    let vc2Options = {
+        name: team2VCName,
+        type: ChannelType.GuildVoice,
+        userLimit: (game.team2.length || 1) + 1,
+        reason: "VC2 for Valorant custom match"
+    }
+
+    const team1VC = await categoryChannel.children.create(vc1Options)
+    const team2VC = await categoryChannel.children.create(vc2Options)
+
+    // move players to team VCs
+    movePlayersToTeamVoiceChannels(game.team1, team1VC, interaction.guild.members)
+    movePlayersToTeamVoiceChannels(game.team2, team2VC, interaction.guild.members)
+
+    return
+}
+
+function movePlayersToTeamVoiceChannels(players, teamChannel, guildMemberManager){
+    players.forEach(async member => {
+        member = await guildMemberManager.fetch(member.userId)
+		member.voice.setChannel(teamChannel)
+	})
 }

--- a/models/game.js
+++ b/models/game.js
@@ -25,7 +25,7 @@ module.exports = class Game {
     }
 
     whoseTurnToPick(){
-        return this.isCaptain1TurnToPick ? this.captain1 : this.captain2;
+        return this.lastPick === this.captain1.userId ? this.captain2 : this.captain1;
     }
 
     isCaptain1TurnToPick(){
@@ -33,7 +33,7 @@ module.exports = class Game {
             return true;
         }
         
-        return this.lastPick === this.captain1;
+        return this.lastPick === this.captain1.userId;
     }
 
     setCaptains(team1Captain, team2Captain){

--- a/models/game.js
+++ b/models/game.js
@@ -12,6 +12,7 @@ module.exports = class Game {
         this.availablePlayers = [];
         this.team1 = [];
         this.team2 = [];
+        this.draftLog = "";
     }
 
     generateUniqueGameId(guildId, creatorId){
@@ -31,8 +32,16 @@ module.exports = class Game {
     setCaptains(team1Captain, team2Captain){
         this.captain1 = team1Captain;
         this.captain2 = team2Captain;
-        this.team1.push(team1Captain);
-        this.team2.push(team2Captain);
+        this.team1.push(this.captain1);
+        this.team2.push(this.captain2);
+
+
+        // remove captains from availablePlayers
+        const captain1Index = this.availablePlayers.findIndex(player => player.userId === this.captain1.userId);
+        const captain2Index = this.availablePlayers.findIndex(player => player.userId === this.captain2.userId);
+
+        this.availablePlayers.splice(captain1Index, 1);
+        this.availablePlayers.splice(captain2Index, 1);
     }
 
     draftPlayer(playerId, captainId){
@@ -47,6 +56,7 @@ module.exports = class Game {
 
         // if player not found, simply return
         if(!chosenPlayer) {
+            console.log(`player not found - playerId - ${playerId}`)
             return
         }
 
@@ -59,6 +69,18 @@ module.exports = class Game {
             this.lastPick = this.captain2.userId
             return [chosenPlayer, 'team 2']
         }
+    }
+
+    appendToDraftLog(msg) {
+        if(!this.draftLog) {
+            this.draftLog = msg
+            this.update()
+            return
+        }
+
+        this.draftLog = this.draftLog + "\n\n" + msg    
+        this.update()
+        return
     }
 
     saveNewGame(){

--- a/models/game.js
+++ b/models/game.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const { databaseFileName } = require('./../config.json');
+
+module.exports = class Game {
+    constructor(uniqueId){
+        this.id = uniqueId;
+        this.captain1;
+        this.captain2;
+        this.lastPick;
+        this.team1 = [];
+        this.team2 = [];
+    }
+
+    // get getId(){
+    //     return this.id;
+    // }
+
+    // get captain1(){
+    //     return this.captain1;
+    // }
+
+    // set captain1(user){
+    //     this.captain1 = user;
+    //     return;
+    // }
+
+    // get captain2(){
+    //     return this.captain2;
+    // }
+
+    // set captain2(user){
+    //     this.captain2 = user;
+    //     return;
+    // }
+
+    // get team1(){
+    //     return this.team1;
+    // }
+
+    // get team2(){
+    //     return this.team2;
+    // }
+
+    whoseTurnToPick(){
+        return this.isCaptain1TurnToPick ? this.captain1 : this.captain2;
+    }
+
+    isCaptain1TurnToPick(){
+        return this.lastPick === this.captain1;
+    }
+
+    setCaptains(team1Captain){
+        this.team1.push(team1Captain);
+        // this.team2.push(team2Captain);
+    }
+
+    save(){
+        const jsonData = JSON.stringify(this, null, 2);
+
+        // if file doesn't exist, create it
+        if(!fs.existsSync(databaseFileName)) {
+            fs.writeFileSync(databaseFileName, jsonData, 'utf8');
+            return
+        }
+
+        // if file exists but is empty
+        fs.stat(databaseFileName, (err, fileStats) => {
+            if(err) {
+                console.log("Error saving game to file - ", err)
+                return
+            }
+
+            if (fileStats.size === 0) {
+                fs.writeFileSync(databaseFileName, jsonData, 'utf8');
+                return
+            }
+        })
+
+        // if file exists and is not empty
+        fs.appendFile(databaseFileName, `,\n${jsonData}`, 'utf8', (err) => {
+            if (err){
+                console.log("Error saving game to file - ", err);
+                return
+            }
+            console.log(`Object appended to "${databaseFileName}`);
+        });
+
+    }
+}

--- a/models/game.js
+++ b/models/game.js
@@ -29,6 +29,10 @@ module.exports = class Game {
     }
 
     isCaptain1TurnToPick(){
+        if (this.lastPick = null) {
+            return true;
+        }
+        
         return this.lastPick === this.captain1;
     }
 

--- a/repos/gameRepo.js
+++ b/repos/gameRepo.js
@@ -68,6 +68,7 @@ function createGameFromData(data){
     game.availablePlayers = data.availablePlayers || [];
     game.team1 = data.team1 || [];
     game.team2 = data.team2 || [];
+    game.draftLog = data.draftLog || '';
 
     return game;
 }

--- a/repos/gameRepo.js
+++ b/repos/gameRepo.js
@@ -32,6 +32,22 @@ function getGameByCaptainIdAndServerId(captainId, guildId){
     return createGameFromData(allGamesFromGuild[gameId]);
 }
 
+function getGameByGuildIdAndGameId(guildId, gameId) {
+    let allGames = getGamesFromDBFile();
+    if (Object.keys(allGames).length === 0){
+        // no games in db file
+        return false
+    }
+
+    let gameData = allGames[guildId][gameId] || {};
+    if(Object.keys(gameData).length === 0){
+        // could not find game
+        return false;
+    }
+
+    return createGameFromData(gameData);
+}
+
 function getGamesFromDBFile(){
     if(fs.readFileSync(databaseFileName, 'utf8').length === 0){
         // no data in db file
@@ -57,5 +73,6 @@ function createGameFromData(data){
 }
 
 module.exports = {
-    getGameByCaptainIdAndServerId
+    getGameByCaptainIdAndServerId,
+    getGameByGuildIdAndGameId
 }

--- a/repos/gameRepo.js
+++ b/repos/gameRepo.js
@@ -1,4 +1,4 @@
-function getGameByCaptainId(captainId){
+function getGameByCaptainIdAndServerId(captainId, serverId){
     return false;
 }
 

--- a/repos/gameRepo.js
+++ b/repos/gameRepo.js
@@ -1,0 +1,7 @@
+function getGameByCaptainId(captainId){
+    return false;
+}
+
+module.exports = {
+    getGameByCaptainId
+}

--- a/repos/gameRepo.js
+++ b/repos/gameRepo.js
@@ -1,7 +1,61 @@
-function getGameByCaptainIdAndServerId(captainId, serverId){
-    return false;
+const fs = require('fs');
+const Game = require('./../models/game')
+const { databaseFileName } = require('./../config.json');
+
+function getGameByCaptainIdAndServerId(captainId, guildId){
+    let allGames = getGamesFromDBFile();
+    if (Object.keys(allGames).length === 0) {
+        // no games in db file
+        return false;
+    }
+
+    let allGamesFromGuild = allGames[guildId];
+
+    if(Object.keys(allGamesFromGuild).length === 0){
+        // could not find any games from this guild in db file
+        return false;
+    }
+
+    let gameId = null;
+    for(const[key,value] of Object.entries(allGamesFromGuild)){
+        if(value.captain1.userId === captainId || value.captain2.userId === captainId) {
+            gameId = key
+            break;
+        }
+    }
+
+    if(gameId === null){
+        // no games with matching captainId
+        return false;
+    }
+
+    return createGameFromData(allGamesFromGuild[gameId]);
+}
+
+function getGamesFromDBFile(){
+    if(fs.readFileSync(databaseFileName, 'utf8').length === 0){
+        // no data in db file
+        return {}
+    }
+
+    let existingGameData = JSON.parse(fs.readFileSync(databaseFileName, 'utf8'));
+    return existingGameData
+}
+
+function createGameFromData(data){
+    let game = new Game(data.id, data.captain1)
+    game.id = data.id || 0;
+    game.guildId = data.guildId || 0;
+    game.captain1 = data.captain1 || {};
+    game.captain2 = data.captain2 || {};
+    game.lastPick = data.lastPick || null;
+    game.availablePlayers = data.availablePlayers || [];
+    game.team1 = data.team1 || [];
+    game.team2 = data.team2 || [];
+
+    return game;
 }
 
 module.exports = {
-    getGameByCaptainId
+    getGameByCaptainIdAndServerId
 }


### PR DESCRIPTION
This PR will add 2 new slash commands: /team_captains and /draft

These are meant to be used in conjunction with each other. The flow is as follows:
- The /team_captains command is used to initiate the team captains style team building. It will randomly pick 2 captains from the voice channel from which the command was issued. A minimum of 3 members must be in the vc.
- Once team captains have been selected, the /draft command is used to initiate the player draft. Each captain will alternatively select players using the provided select menu. Once all players have been drafted, either captain may select the newly available 'start game' option in the select menu
- Once the 'start game' option has been selected, a new vc will be created for each team and each member will be moved to their respective team vc. 
- Once the game is over, the /end_game command can be used to move all players back into a single vc 